### PR TITLE
Handle conflicting --show-artifacts and --no-artifacts flags

### DIFF
--- a/src/envoic/cli.py
+++ b/src/envoic/cli.py
@@ -174,6 +174,12 @@ def scan(
         include_dotenv=include_dotenv,
         include_artifacts=include_artifacts,
     )
+    if show_artifacts and not include_artifacts:
+    typer.echo(
+        "Error: --show-artifacts cannot be used together with --no-artifacts.",
+        err=True,
+    )
+    raise typer.Exit(code=1)
 
     if json_output:
         typer.echo(json.dumps(to_serializable_dict(result), indent=2))

--- a/src/envoic/cli.py
+++ b/src/envoic/cli.py
@@ -379,6 +379,13 @@ def clean(
         yes=yes,
     )
 
+def test_conflicting_artifact_flags_error():
+    result = runner.invoke(
+        app,
+        ["scan", "--show-artifacts", "--no-artifacts"],
+    )
+    assert result.exit_code != 0
+    assert "cannot be used together" in result.output.lower()
 
 def main() -> None:
     """Console-script entrypoint."""


### PR DESCRIPTION
This PR fixes the behavior when --show-artifacts and --no-artifacts
are provided together. The CLI now exits with a clear error message
instead of producing empty artifact output.

A test has been added to cover this scenario.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conflict detection for artifact flags. The CLI now validates that `--show-artifacts` and `--no-artifacts` cannot be used simultaneously and displays a clear error message.

* **Tests**
  * Added test coverage to verify conflicting flag detection works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->