### PR TITLE
Fix artifact hint to match CLI flag

### DIFF
--- a/src/envoic/report.py
+++ b/src/envoic/report.py
@@ -257,7 +257,7 @@ def format_report(
         lines.append("ARTIFACT DETAILS")
         lines.append("─" * 58)
         lines.append(
-            "  (hidden by default; run with --artifact to show detailed breakdown)"
+            "  (hidden by default; run with --show-artifacts to show detailed breakdown)"
         )
         lines.append("─" * 58)
         lines.append("")


### PR DESCRIPTION
This PR fixes the hint in the report to use the correct CLI flag `--show-artifacts` instead of the incorrect `--artifact`.

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text to clarify the correct command-line flag for revealing artifact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->