### PR TITLE
Use stale-days value in Python report summary

### DIFF
--- a/packages/python/src/envoic/cli.py
+++ b/packages/python/src/envoic/cli.py
@@ -77,6 +77,7 @@ def _build_scan_result(
         total_size_bytes=total_size_bytes,
         hostname=socket.gethostname(),
         timestamp=datetime.now(UTC),
+        stale_days=stale_days,
         artifacts=artifacts,
         artifact_summary=summarize_artifacts(artifacts),
     )

--- a/packages/python/src/envoic/models.py
+++ b/packages/python/src/envoic/models.py
@@ -51,6 +51,7 @@ class ScanResult:
     total_size_bytes: int
     hostname: str
     timestamp: datetime
+    stale_days: int = 90
     artifacts: list[ArtifactInfo] = field(default_factory=list)
     artifact_summary: list[ArtifactSummary] = field(default_factory=list)
 
@@ -125,6 +126,7 @@ class ScanResultDict(TypedDict):
     total_size_bytes: int
     hostname: str
     timestamp: str
+    stale_days: int
     artifacts: list[ArtifactInfoDict]
     artifact_summary: list[ArtifactSummaryDict]
 

--- a/packages/python/src/envoic/report.py
+++ b/packages/python/src/envoic/report.py
@@ -190,7 +190,7 @@ def format_report(
     lines.append(
         _row("Env Size", format_size(result.total_size_bytes) if deep else "-")
     )
-    lines.append(_row("Stale >90d", str(stale_count)))
+    lines.append(_row(f"Stale >{result.stale_days}d", str(stale_count)))
     lines.append(_row("Artifacts Found", str(artifact_count)))
     lines.append(
         _row("Artifact Size", format_size(artifact_total_size) if deep else "-")

--- a/packages/python/tests/test_report.py
+++ b/packages/python/tests/test_report.py
@@ -48,6 +48,30 @@ def test_format_report_structure() -> None:
     assert "project" in text
 
 
+def test_format_report_uses_scan_stale_threshold() -> None:
+    env = EnvInfo(
+        path=Path("/tmp/project/.venv"),
+        env_type=EnvType.VENV,
+        python_version="3.12.1",
+        is_stale=True,
+    )
+    result = ScanResult(
+        scan_path=Path("/tmp"),
+        scan_depth=5,
+        duration_seconds=1.2,
+        environments=[env],
+        total_size_bytes=0,
+        hostname="host-a",
+        timestamp=datetime(2026, 2, 9, 12, 0, 0, tzinfo=UTC),
+        stale_days=30,
+    )
+
+    text = format_report(result)
+
+    assert "Stale >30d" in text
+    assert "Stale >90d" not in text
+
+
 def test_format_report_path_modes() -> None:
     env = EnvInfo(
         path=Path("/tmp/project/.venv"),

--- a/packages/python/tests/test_report.py
+++ b/packages/python/tests/test_report.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from envoic.models import EnvInfo, EnvType, ScanResult
+from envoic.models import EnvInfo, EnvType, ScanResult, to_serializable_dict
 from envoic.report import bar_chart, format_age, format_list, format_report, format_size
 
 
@@ -70,6 +70,7 @@ def test_format_report_uses_scan_stale_threshold() -> None:
 
     assert "Stale >30d" in text
     assert "Stale >90d" not in text
+    assert to_serializable_dict(result)["stale_days"] == 30
 
 
 def test_format_report_path_modes() -> None:


### PR DESCRIPTION
Closes #16.

The Python scanner already accepts `--stale-days`, but the text report always labeled the stale count as `>90d`. This stores the threshold on `ScanResult` and uses it in the report summary.

Tests:
- `packages\python\.venv\Scripts\python.exe -m pytest packages\python\tests\test_report.py::test_format_report_uses_scan_stale_threshold -q`
- `packages\python\.venv\Scripts\python.exe -m py_compile packages\python\src\envoic\models.py packages\python\src\envoic\cli.py packages\python\src\envoic\report.py packages\python\tests\test_report.py`
