### PR TITLE
Add limit option for Python scan and list output

### DIFF
--- a/packages/python/src/envoic/cli.py
+++ b/packages/python/src/envoic/cli.py
@@ -157,6 +157,9 @@ def scan(
         "-a",
         help="Show detailed artifact-level report sections.",
     ),
+    limit: int | None = typer.Option(
+        None, "--limit", min=1, help="Cap displayed environments."
+    ),
     path_mode: PathMode = typer.Option(
         "name",
         "--path-mode",
@@ -186,6 +189,7 @@ def scan(
             path_mode=path_mode,
             deep=deep,
             show_artifact_details=show_artifacts,
+            limit=limit,
         ),
         use_rich=rich_output,
     )
@@ -203,6 +207,9 @@ def list_environments(
     ),
     include_dotenv: bool = typer.Option(
         False, "--include-dotenv", help="Include plain .env directories."
+    ),
+    limit: int | None = typer.Option(
+        None, "--limit", min=1, help="Cap displayed environments."
     ),
     path_mode: PathMode = typer.Option(
         "name",
@@ -224,7 +231,10 @@ def list_environments(
     )
     _print_output(
         format_list(
-            result.environments, path_mode=path_mode, base_path=result.scan_path
+            result.environments,
+            path_mode=path_mode,
+            base_path=result.scan_path,
+            limit=limit,
         ),
         use_rich=rich_output,
     )

--- a/packages/python/src/envoic/report.py
+++ b/packages/python/src/envoic/report.py
@@ -170,10 +170,12 @@ def format_report(
     path_mode: PathMode = "name",
     deep: bool = False,
     show_artifact_details: bool = False,
+    limit: int | None = None,
 ) -> str:
     stale_count = sum(1 for env in result.environments if env.is_stale)
     artifact_count = sum(item.count for item in result.artifact_summary)
     artifact_total_size = sum(item.total_size_bytes for item in result.artifact_summary)
+    display_envs = sorted(result.environments, key=lambda item: str(item.path))[:limit]
 
     lines: list[str] = []
     lines.append(_box_top())
@@ -205,8 +207,7 @@ def format_report(
     if not result.environments:
         lines.append("  (no environments found)")
     else:
-        sorted_envs = sorted(result.environments, key=lambda item: str(item.path))
-        for index, env in enumerate(sorted_envs, start=1):
+        for index, env in enumerate(display_envs, start=1):
             lines.append(
                 _table_row(
                     index,
@@ -263,7 +264,7 @@ def format_report(
         lines.append("")
     lines.append(
         _size_distribution(
-            result.environments, path_mode=path_mode, base_path=result.scan_path
+            display_envs, path_mode=path_mode, base_path=result.scan_path
         )
     )
 
@@ -275,10 +276,11 @@ def format_list(
     *,
     path_mode: PathMode = "name",
     base_path: Path | None = None,
+    limit: int | None = None,
 ) -> str:
     lines = [_table_header(), "─" * 58]
     for index, env in enumerate(
-        sorted(environments, key=lambda item: str(item.path)), start=1
+        sorted(environments, key=lambda item: str(item.path))[:limit], start=1
     ):
         lines.append(_table_row(index, env, path_mode=path_mode, base_path=base_path))
     if len(lines) == 2:

--- a/packages/python/tests/test_report.py
+++ b/packages/python/tests/test_report.py
@@ -22,6 +22,16 @@ def test_bar_chart() -> None:
     assert bar_chart(100, 100, width=10) == "[██████████]"
 
 
+def _env(name: str, *, size_bytes: int = 1024) -> EnvInfo:
+    return EnvInfo(
+        path=Path(f"/tmp/{name}/.venv"),
+        env_type=EnvType.VENV,
+        python_version="3.12.1",
+        size_bytes=size_bytes,
+        modified=datetime.now(UTC),
+    )
+
+
 def test_format_report_structure() -> None:
     env = EnvInfo(
         path=Path("/tmp/project/.venv"),
@@ -46,6 +56,29 @@ def test_format_report_structure() -> None:
     assert "ENVIRONMENTS" in text
     assert "SIZE DISTRIBUTION" in text
     assert "project" in text
+
+
+def test_format_report_limits_displayed_environments() -> None:
+    result = ScanResult(
+        scan_path=Path("/tmp"),
+        scan_depth=5,
+        duration_seconds=1.2,
+        environments=[
+            _env("project-alpha", size_bytes=1024),
+            _env("project-beta", size_bytes=2048),
+            _env("project-gamma", size_bytes=4096),
+        ],
+        total_size_bytes=7168,
+        hostname="host-a",
+        timestamp=datetime(2026, 2, 9, 12, 0, 0, tzinfo=UTC),
+    )
+
+    text = format_report(result, deep=True, limit=2)
+
+    assert "3" in next(line for line in text.splitlines() if "Envs Found" in line)
+    assert "project-alpha" in text
+    assert "project-beta" in text
+    assert "project-gamma" not in text
 
 
 def test_format_report_path_modes() -> None:
@@ -85,6 +118,21 @@ def test_format_list_relative_paths() -> None:
     text = format_list([env], path_mode="relative", base_path=Path("/tmp"))
     assert "project" in text
     assert "project/.venv" not in text
+
+
+def test_format_list_limits_displayed_environments() -> None:
+    text = format_list(
+        [
+            _env("project-alpha"),
+            _env("project-beta"),
+            _env("project-gamma"),
+        ],
+        limit=1,
+    )
+
+    assert "project-alpha" in text
+    assert "project-beta" not in text
+    assert "project-gamma" not in text
 
 
 def test_format_report_show_artifact_details_false() -> None:


### PR DESCRIPTION
Closes #8.

Adds `--limit` to Python `scan` and `list` text output. The scan result and JSON output stay complete; the limit only caps displayed environment rows and the report summary still shows the full environment count.

Tests:
- `packages\python\.venv\Scripts\python.exe -m pytest packages\python\tests\test_report.py::test_format_report_limits_displayed_environments packages\python\tests\test_report.py::test_format_list_limits_displayed_environments -q`
- `packages\python\.venv\Scripts\python.exe -m pytest packages\python\tests\test_report.py -q -k "not path_modes"`
- `packages\python\.venv\Scripts\python.exe -m py_compile packages\python\src\envoic\cli.py packages\python\src\envoic\report.py packages\python\tests\test_report.py`
- CLI smoke check for `scan --limit 1` and `list --limit 1` with `PYTHONIOENCODING=utf-8`