### PR TITLE
Document Python artifact scan flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ uvx envoic scan ~/projects --show-artifacts
 uvx envoic scan ~/projects --no-artifacts
 ```
 
+`--show-artifacts` needs artifact detection enabled, so combining it with
+`--no-artifacts` is rejected with an error.
+
 [Python package →](./packages/python/)
 
 ## JavaScript

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Find scattered `.venv` directories, Python caches, build artifacts, and more.
 uvx envoic scan ~/projects
 ```
 
+Artifact scanning is enabled by default for Python scans. Use
+`--no-artifacts` to report only environments, or `--show-artifacts` to expand
+the artifact summary into detailed rows:
+
+```bash
+uvx envoic scan ~/projects --show-artifacts
+uvx envoic scan ~/projects --no-artifacts
+```
+
 [Python package →](./packages/python/)
 
 ## JavaScript

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -16,7 +16,9 @@ envoic is currently CLI-first and has no config file.
 
 Artifact detection is enabled by default for `scan`. Use `--no-artifacts` when
 you only want Python environments in the report. Use `--show-artifacts` to show
-the detailed artifact rows instead of the default summary placeholder.
+the detailed artifact rows instead of the default summary placeholder. Because
+`--show-artifacts` needs artifact detection, combining it with `--no-artifacts`
+is rejected with an error.
 
 ## List command options
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -9,8 +9,14 @@ envoic is currently CLI-first and has no config file.
 - `--json` (default: `false`)
 - `--stale-days` (default: `90`)
 - `--include-dotenv` (default: `false`)
+- `--artifacts` / `--no-artifacts` (default: `--artifacts`)
+- `--show-artifacts`, `-a` (default: `false`)
 - `--path-mode` (default: `name`; options: `name`, `relative`, `absolute`)
 - `--rich` (default: `false`)
+
+Artifact detection is enabled by default for `scan`. Use `--no-artifacts` when
+you only want Python environments in the report. Use `--show-artifacts` to show
+the detailed artifact rows instead of the default summary placeholder.
 
 ## List command options
 


### PR DESCRIPTION
Closes #18.

Documents the Python artifact flags in the README and configuration guide:

- `--artifacts` / `--no-artifacts`
- `--show-artifacts` / `-a`

Check:
- `npm.cmd --prefix docs run build`