### PR TITLE
Add sort option for Python output

### DIFF
--- a/packages/python/src/envoic/cli.py
+++ b/packages/python/src/envoic/cli.py
@@ -28,7 +28,7 @@ from .models import (
     ScanResult,
     to_serializable_dict,
 )
-from .report import PathMode, format_info, format_list, format_report
+from .report import PathMode, SortMode, format_info, format_list, format_report
 from .scanner import scan as scan_paths
 
 app = typer.Typer(help="Discover and report Python virtual environments.")
@@ -162,6 +162,11 @@ def scan(
         "--path-mode",
         help="How to render environment path columns: name, relative, absolute.",
     ),
+    sort: SortMode = typer.Option(
+        "path",
+        "--sort",
+        help="Sort environment rows by path, size, age, or python.",
+    ),
     rich_output: bool = typer.Option(
         False, "--rich", help="Use optional rich-rendered output."
     ),
@@ -184,6 +189,7 @@ def scan(
         format_report(
             result,
             path_mode=path_mode,
+            sort=sort,
             deep=deep,
             show_artifact_details=show_artifacts,
         ),
@@ -209,6 +215,11 @@ def list_environments(
         "--path-mode",
         help="How to render environment path columns: name, relative, absolute.",
     ),
+    sort: SortMode = typer.Option(
+        "path",
+        "--sort",
+        help="Sort environment rows by path, size, age, or python.",
+    ),
     rich_output: bool = typer.Option(
         False, "--rich", help="Use optional rich-rendered output."
     ),
@@ -224,7 +235,10 @@ def list_environments(
     )
     _print_output(
         format_list(
-            result.environments, path_mode=path_mode, base_path=result.scan_path
+            result.environments,
+            path_mode=path_mode,
+            sort=sort,
+            base_path=result.scan_path,
         ),
         use_rich=rich_output,
     )

--- a/packages/python/src/envoic/cli.py
+++ b/packages/python/src/envoic/cli.py
@@ -172,6 +172,8 @@ def scan(
     ),
 ) -> None:
     """Scan a filesystem path for Python environments."""
+    # Sorting by size needs size metadata, which is only computed with --deep.
+    deep = deep or sort == "size"
     result = _build_scan_result(
         path,
         depth,
@@ -225,6 +227,8 @@ def list_environments(
     ),
 ) -> None:
     """Print a compact environments table."""
+    # Sorting by size needs size metadata, which is only computed with --deep.
+    deep = deep or sort == "size"
     result = _build_scan_result(
         path,
         depth,

--- a/packages/python/src/envoic/report.py
+++ b/packages/python/src/envoic/report.py
@@ -16,6 +16,7 @@ from .utils import (
 
 REPORT_WIDTH = 58
 PathMode = Literal["name", "relative", "absolute"]
+SortMode = Literal["path", "size", "age", "python"]
 
 
 def _box_top(width: int = REPORT_WIDTH) -> str:
@@ -98,6 +99,49 @@ def _table_row(
     )
 
 
+def _python_version_sort_key(version: str | None) -> tuple[bool, tuple[int, ...], str]:
+    if version is None:
+        return (True, (), "")
+
+    numeric_parts: list[int] = []
+    for part in version.split("."):
+        if not part.isdigit():
+            break
+        numeric_parts.append(int(part))
+
+    return (False, tuple(numeric_parts), version)
+
+
+def _sort_environments(environments: list[EnvInfo], sort: SortMode) -> list[EnvInfo]:
+    if sort == "size":
+        return sorted(
+            environments,
+            key=lambda item: (
+                item.size_bytes is None,
+                -(item.size_bytes or 0),
+                str(item.path),
+            ),
+        )
+    if sort == "age":
+        return sorted(
+            environments,
+            key=lambda item: (
+                item.modified is None,
+                item.modified.isoformat() if item.modified else "",
+                str(item.path),
+            ),
+        )
+    if sort == "python":
+        return sorted(
+            environments,
+            key=lambda item: (
+                *_python_version_sort_key(item.python_version),
+                str(item.path),
+            ),
+        )
+    return sorted(environments, key=lambda item: str(item.path))
+
+
 def _size_distribution(
     environments: list[EnvInfo], *, path_mode: PathMode, base_path: Path | None = None
 ) -> str:
@@ -168,6 +212,7 @@ def format_report(
     *,
     title: str = "ENVOIC - Python Environment Report",
     path_mode: PathMode = "name",
+    sort: SortMode = "path",
     deep: bool = False,
     show_artifact_details: bool = False,
 ) -> str:
@@ -205,7 +250,7 @@ def format_report(
     if not result.environments:
         lines.append("  (no environments found)")
     else:
-        sorted_envs = sorted(result.environments, key=lambda item: str(item.path))
+        sorted_envs = _sort_environments(result.environments, sort)
         for index, env in enumerate(sorted_envs, start=1):
             lines.append(
                 _table_row(
@@ -263,7 +308,9 @@ def format_report(
         lines.append("")
     lines.append(
         _size_distribution(
-            result.environments, path_mode=path_mode, base_path=result.scan_path
+            _sort_environments(result.environments, sort),
+            path_mode=path_mode,
+            base_path=result.scan_path,
         )
     )
 
@@ -274,12 +321,11 @@ def format_list(
     environments: list[EnvInfo],
     *,
     path_mode: PathMode = "name",
+    sort: SortMode = "path",
     base_path: Path | None = None,
 ) -> str:
     lines = [_table_header(), "─" * 58]
-    for index, env in enumerate(
-        sorted(environments, key=lambda item: str(item.path)), start=1
-    ):
+    for index, env in enumerate(_sort_environments(environments, sort), start=1):
         lines.append(_table_row(index, env, path_mode=path_mode, base_path=base_path))
     if len(lines) == 2:
         lines.append("  (no environments found)")

--- a/packages/python/tests/test_report.py
+++ b/packages/python/tests/test_report.py
@@ -5,6 +5,39 @@ from envoic.models import EnvInfo, EnvType, ScanResult
 from envoic.report import bar_chart, format_age, format_list, format_report, format_size
 
 
+def _env(
+    name: str,
+    *,
+    python_version: str | None = "3.12.1",
+    size_bytes: int | None = None,
+    modified: datetime | None = None,
+) -> EnvInfo:
+    return EnvInfo(
+        path=Path(f"/tmp/{name}/.venv"),
+        env_type=EnvType.VENV,
+        python_version=python_version,
+        size_bytes=size_bytes,
+        modified=modified,
+    )
+
+
+def _scan_result(environments: list[EnvInfo]) -> ScanResult:
+    return ScanResult(
+        scan_path=Path("/tmp"),
+        scan_depth=5,
+        duration_seconds=1.2,
+        environments=environments,
+        total_size_bytes=sum(env.size_bytes or 0 for env in environments),
+        hostname="host-a",
+        timestamp=datetime(2026, 2, 9, 12, 0, 0, tzinfo=UTC),
+    )
+
+
+def _assert_order(text: str, *labels: str) -> None:
+    positions = [text.index(label) for label in labels]
+    assert positions == sorted(positions)
+
+
 def test_format_size() -> None:
     assert format_size(512) == "512B"
     assert format_size(1024) == "1K"
@@ -85,6 +118,64 @@ def test_format_list_relative_paths() -> None:
     text = format_list([env], path_mode="relative", base_path=Path("/tmp"))
     assert "project" in text
     assert "project/.venv" not in text
+
+
+def test_format_list_sorts_by_path() -> None:
+    text = format_list([_env("project-z"), _env("project-a")], sort="path")
+
+    _assert_order(text, "project-a", "project-z")
+
+
+def test_format_list_sorts_by_size() -> None:
+    text = format_list(
+        [
+            _env("small", size_bytes=1024),
+            _env("unknown"),
+            _env("large", size_bytes=1024 * 1024),
+        ],
+        sort="size",
+    )
+
+    _assert_order(text, "large", "small", "unknown")
+
+
+def test_format_list_sorts_by_age() -> None:
+    text = format_list(
+        [
+            _env("new", modified=datetime(2026, 2, 9, tzinfo=UTC)),
+            _env("unknown"),
+            _env("old", modified=datetime(2025, 2, 9, tzinfo=UTC)),
+        ],
+        sort="age",
+    )
+
+    _assert_order(text, "old", "new", "unknown")
+
+
+def test_format_list_sorts_by_python_version() -> None:
+    text = format_list(
+        [
+            _env("py310", python_version="3.10.0"),
+            _env("missing", python_version=None),
+            _env("py39", python_version="3.9.18"),
+        ],
+        sort="python",
+    )
+
+    _assert_order(text, "py39", "py310", "missing")
+
+
+def test_format_report_uses_requested_sort_order() -> None:
+    result = _scan_result(
+        [
+            _env("small", size_bytes=1024),
+            _env("large", size_bytes=1024 * 1024),
+        ]
+    )
+
+    text = format_report(result, sort="size", deep=True)
+
+    _assert_order(text, "large", "small")
 
 
 def test_format_report_show_artifact_details_false() -> None:

--- a/packages/python/tests/test_report.py
+++ b/packages/python/tests/test_report.py
@@ -227,3 +227,26 @@ def test_format_report_show_artifact_details_true() -> None:
 
     assert "ARTIFACTS" in text
     assert "hidden by default" not in text
+
+
+def test_scan_sort_size_implies_deep(tmp_path: Path) -> None:
+    from typer.testing import CliRunner
+
+    from envoic.cli import app
+
+    for name, kb in (("aaa", 1), ("zzz", 64)):
+        venv = tmp_path / name / ".venv"
+        venv.mkdir(parents=True)
+        (venv / "pyvenv.cfg").write_text(
+            "home = /usr/bin\nversion = 3.12.1\n", encoding="utf-8"
+        )
+        (venv / "blob.bin").write_bytes(b"\0" * (kb * 1024))
+
+    result = CliRunner().invoke(
+        app, ["scan", str(tmp_path), "--sort", "size", "--no-artifacts"]
+    )
+
+    assert result.exit_code == 0
+    # Larger env (zzz) sorts before the smaller (aaa) even though --deep was
+    # not passed: sorting by size must imply the size computation.
+    assert result.output.index("zzz") < result.output.index("aaa")


### PR DESCRIPTION
Closes #7.

Adds `--sort path|size|age|python` to the Python `scan` and `list` text output. Path stays the default; size puts larger envs first, age puts older envs first, and python sorts by parsed version.

Tests:
- `packages\python\.venv\Scripts\python.exe -m pytest packages\python\tests\test_report.py -q -k `"sort`"`
- `packages\python\.venv\Scripts\python.exe -m pytest packages\python\tests\test_report.py -q -k `"not path_modes`"`
- `packages\python\.venv\Scripts\python.exe -m py_compile packages\python\src\envoic\cli.py packages\python\src\envoic\report.py packages\python\tests\test_report.py`
- CLI smoke: `list --sort python`, `scan --sort size`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--sort` option to the `scan` and `list` commands, letting you order environments by path, size, age, or Python version.
  * Size-based sorting now automatically includes the extra details needed to calculate sizes.

* **Bug Fixes**
  * Improved report and list ordering so the selected sort option is applied consistently across output sections.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->