### PR TITLE
Add Python environment health command

### DIFF
--- a/packages/python/src/envoic/cli.py
+++ b/packages/python/src/envoic/cli.py
@@ -11,6 +11,7 @@ import typer
 from . import __version__
 from .artifacts import summarize_artifacts, summarize_with_empty_patterns
 from .detector import activation_hint, detect_environment, list_top_packages
+from .health import check_environments_health, format_health_report, health_to_dict
 from .manager import (
     confirm_careful_artifacts,
     confirm_deletion,
@@ -226,6 +227,41 @@ def list_environments(
         format_list(
             result.environments, path_mode=path_mode, base_path=result.scan_path
         ),
+        use_rich=rich_output,
+    )
+
+
+@app.command()
+def health(
+    path: Path = typer.Argument(Path("."), exists=True, file_okay=False, dir_okay=True),
+    depth: int = typer.Option(5, "--depth", "-d", min=1, help="Max directory depth."),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output JSON report.", rich_help_panel="Output"
+    ),
+    include_dotenv: bool = typer.Option(
+        False, "--include-dotenv", help="Include plain .env directories."
+    ),
+    rich_output: bool = typer.Option(
+        False, "--rich", help="Use optional rich-rendered output."
+    ),
+) -> None:
+    """Check discovered Python environments for common breakage."""
+    result = _build_scan_result(
+        path,
+        depth,
+        deep=False,
+        stale_days=90,
+        include_dotenv=include_dotenv,
+        include_artifacts=False,
+    )
+    checks = check_environments_health(result.environments)
+
+    if json_output:
+        typer.echo(json.dumps([health_to_dict(check) for check in checks], indent=2))
+        raise typer.Exit(0)
+
+    _print_output(
+        format_health_report(checks, base_path=result.scan_path),
         use_rich=rich_output,
     )
 

--- a/packages/python/src/envoic/cli.py
+++ b/packages/python/src/envoic/cli.py
@@ -255,15 +255,17 @@ def health(
         include_artifacts=False,
     )
     checks = check_environments_health(result.environments)
+    exit_code = 1 if any(check.status == "BROKEN" for check in checks) else 0
 
     if json_output:
         typer.echo(json.dumps([health_to_dict(check) for check in checks], indent=2))
-        raise typer.Exit(0)
+        raise typer.Exit(exit_code)
 
     _print_output(
         format_health_report(checks, base_path=result.scan_path),
         use_rich=rich_output,
     )
+    raise typer.Exit(exit_code)
 
 
 @app.command()

--- a/packages/python/src/envoic/health.py
+++ b/packages/python/src/envoic/health.py
@@ -68,7 +68,10 @@ def _pyvenv_issues(path: Path) -> list[str]:
     if not pyvenv_cfg.is_file():
         return ["missing pyvenv.cfg"]
 
-    data = parse_pyvenv_cfg(path)
+    try:
+        data = parse_pyvenv_cfg(path)
+    except OSError as err:
+        return [f"pyvenv.cfg unreadable: {err}"]
     home = data.get("home")
     if not home:
         return ["pyvenv.cfg missing home"]
@@ -87,6 +90,13 @@ def _activation_issues(path: Path) -> list[str]:
 
 
 def check_environment_health(env: EnvInfo) -> HealthCheck:
+    if not env.path.is_dir():
+        return HealthCheck(
+            path=env.path,
+            status="BROKEN",
+            issues=["environment directory missing or not a directory"],
+        )
+
     broken = _python_issues(env.path)
     warnings: list[str] = []
     if env.env_type != EnvType.CONDA:

--- a/packages/python/src/envoic/health.py
+++ b/packages/python/src/envoic/health.py
@@ -26,7 +26,12 @@ class HealthCheck:
 
 
 def _python_candidates(path: Path) -> tuple[Path, ...]:
-    return (path / "bin" / "python", path / "Scripts" / "python.exe")
+    return (
+        path / "bin" / "python",
+        path / "Scripts" / "python.exe",
+        # Conda places the interpreter at the environment root on Windows.
+        path / "python.exe",
+    )
 
 
 def _activate_candidates(path: Path) -> tuple[Path, ...]:
@@ -42,31 +47,33 @@ def _relative_issue_path(path: Path, candidate: Path) -> str:
 
 def _existing_python(path: Path) -> Path | None:
     for candidate in _python_candidates(path):
-        if candidate.exists():
+        if candidate.is_file():
             return candidate
     return None
 
 
 def _python_issues(path: Path) -> list[str]:
-    issues: list[str] = []
-    for candidate in _python_candidates(path):
-        if candidate.is_symlink() and not candidate.exists():
-            issues.append(f"dangling symlink: {_relative_issue_path(path, candidate)}")
-            return issues
-
     python_bin = _existing_python(path)
-    if python_bin is None:
-        issues.append("missing python executable")
-    elif not os.access(python_bin, os.X_OK):
-        issues.append(f"not executable: {_relative_issue_path(path, python_bin)}")
+    if python_bin is not None:
+        if not os.access(python_bin, os.X_OK):
+            return [f"not executable: {_relative_issue_path(path, python_bin)}"]
+        return []
 
-    return issues
+    # No working interpreter: a dangling symlink explains it better than a
+    # bare "missing" message, but only report it once we know nothing works.
+    for candidate in _python_candidates(path):
+        if candidate.is_symlink():
+            return [f"dangling symlink: {_relative_issue_path(path, candidate)}"]
+
+    return ["missing python executable"]
 
 
-def _pyvenv_issues(path: Path) -> list[str]:
+def _pyvenv_warnings(path: Path) -> list[str]:
     pyvenv_cfg = path / "pyvenv.cfg"
     if not pyvenv_cfg.is_file():
-        return ["missing pyvenv.cfg"]
+        # pyvenv.cfg is optional: legacy virtualenv-created envs run fine
+        # without it, and the detector already accepts such environments.
+        return []
 
     try:
         data = parse_pyvenv_cfg(path)
@@ -97,10 +104,17 @@ def check_environment_health(env: EnvInfo) -> HealthCheck:
             issues=["environment directory missing or not a directory"],
         )
 
+    # A plain `.env` directory holds dotenv files, not an interpreter, so the
+    # venv-shaped checks below do not apply to it.
+    if env.env_type == EnvType.DOTENV_DIR:
+        return HealthCheck(path=env.path, status="OK", issues=[])
+
     broken = _python_issues(env.path)
     warnings: list[str] = []
-    if env.env_type != EnvType.CONDA:
-        broken.extend(_pyvenv_issues(env.path))
+    if env.env_type == EnvType.VENV:
+        # pyvenv.cfg and activation scripts are venv concepts; their absence or
+        # staleness is informational (WARN), not a broken interpreter (BROKEN).
+        warnings.extend(_pyvenv_warnings(env.path))
         warnings.extend(_activation_issues(env.path))
 
     if broken:
@@ -118,7 +132,11 @@ def check_environments_health(environments: list[EnvInfo]) -> list[HealthCheck]:
 
 
 def health_to_dict(check: HealthCheck) -> HealthCheckDict:
-    return {"path": str(check.path), "status": check.status, "issues": check.issues}
+    return {
+        "path": str(check.path),
+        "status": check.status,
+        "issues": list(check.issues),
+    }
 
 
 def _truncate_text(text: str, width: int) -> str:

--- a/packages/python/src/envoic/health.py
+++ b/packages/python/src/envoic/health.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypedDict
+
+from .detector import parse_pyvenv_cfg
+from .models import EnvInfo, EnvType
+from .utils import format_env_display_path
+
+HealthStatus = Literal["OK", "WARN", "BROKEN"]
+
+
+class HealthCheckDict(TypedDict):
+    path: str
+    status: HealthStatus
+    issues: list[str]
+
+
+@dataclass(slots=True)
+class HealthCheck:
+    path: Path
+    status: HealthStatus
+    issues: list[str]
+
+
+def _python_candidates(path: Path) -> tuple[Path, ...]:
+    return (path / "bin" / "python", path / "Scripts" / "python.exe")
+
+
+def _activate_candidates(path: Path) -> tuple[Path, ...]:
+    return (path / "bin" / "activate", path / "Scripts" / "activate")
+
+
+def _relative_issue_path(path: Path, candidate: Path) -> str:
+    try:
+        return str(candidate.relative_to(path))
+    except ValueError:
+        return str(candidate)
+
+
+def _existing_python(path: Path) -> Path | None:
+    for candidate in _python_candidates(path):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _python_issues(path: Path) -> list[str]:
+    issues: list[str] = []
+    for candidate in _python_candidates(path):
+        if candidate.is_symlink() and not candidate.exists():
+            issues.append(f"dangling symlink: {_relative_issue_path(path, candidate)}")
+            return issues
+
+    python_bin = _existing_python(path)
+    if python_bin is None:
+        issues.append("missing python executable")
+    elif not os.access(python_bin, os.X_OK):
+        issues.append(f"not executable: {_relative_issue_path(path, python_bin)}")
+
+    return issues
+
+
+def _pyvenv_issues(path: Path) -> list[str]:
+    pyvenv_cfg = path / "pyvenv.cfg"
+    if not pyvenv_cfg.is_file():
+        return ["missing pyvenv.cfg"]
+
+    data = parse_pyvenv_cfg(path)
+    home = data.get("home")
+    if not home:
+        return ["pyvenv.cfg missing home"]
+
+    home_path = Path(home).expanduser()
+    if not home_path.exists():
+        return [f"pyvenv.cfg home not found: {home}"]
+
+    return []
+
+
+def _activation_issues(path: Path) -> list[str]:
+    if any(candidate.is_file() for candidate in _activate_candidates(path)):
+        return []
+    return ["missing activate script"]
+
+
+def check_environment_health(env: EnvInfo) -> HealthCheck:
+    broken = _python_issues(env.path)
+    warnings: list[str] = []
+    if env.env_type != EnvType.CONDA:
+        broken.extend(_pyvenv_issues(env.path))
+        warnings.extend(_activation_issues(env.path))
+
+    if broken:
+        status: HealthStatus = "BROKEN"
+    elif warnings:
+        status = "WARN"
+    else:
+        status = "OK"
+
+    return HealthCheck(path=env.path, status=status, issues=[*broken, *warnings])
+
+
+def check_environments_health(environments: list[EnvInfo]) -> list[HealthCheck]:
+    return [check_environment_health(env) for env in environments]
+
+
+def health_to_dict(check: HealthCheck) -> HealthCheckDict:
+    return {"path": str(check.path), "status": check.status, "issues": check.issues}
+
+
+def _truncate_text(text: str, width: int) -> str:
+    if len(text) <= width:
+        return text
+    return f"{text[: width - 3]}..."
+
+
+def format_health_report(checks: list[HealthCheck], *, base_path: Path) -> str:
+    lines = [
+        "ENVIRONMENT HEALTH CHECK",
+        "-" * 58,
+        f"{'Path':<30} {'Status':<6} Issues",
+        "-" * 58,
+    ]
+
+    for check in sorted(checks, key=lambda item: str(item.path)):
+        label = _truncate_text(format_env_display_path(check.path, base_path), 30)
+        issues = "; ".join(check.issues) if check.issues else "-"
+        lines.append(f"{label:<30} {check.status:<6} {issues}")
+
+    if not checks:
+        lines.append("(no environments found)")
+
+    lines.append("-" * 58)
+    healthy = sum(1 for check in checks if check.status == "OK")
+    warnings = sum(1 for check in checks if check.status == "WARN")
+    broken = sum(1 for check in checks if check.status == "BROKEN")
+    lines.append(f"Healthy: {healthy} | Warnings: {warnings} | Broken: {broken}")
+    return "\n".join(lines)

--- a/packages/python/tests/test_health.py
+++ b/packages/python/tests/test_health.py
@@ -82,6 +82,34 @@ def test_check_environment_health_marks_missing_pyvenv_home_broken(
     ]
 
 
+def test_check_environment_health_marks_unreadable_pyvenv_cfg_broken(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env_path = _make_venv(tmp_path, "unreadable")
+
+    def fail_parse(_: Path) -> dict[str, str]:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("envoic.health.parse_pyvenv_cfg", fail_parse)
+
+    check = check_environment_health(_env(env_path))
+
+    assert check.status == "BROKEN"
+    assert check.issues == ["pyvenv.cfg unreadable: permission denied"]
+
+
+def test_check_environment_health_marks_missing_env_directory_broken(
+    tmp_path: Path,
+) -> None:
+    env_path = tmp_path / "missing" / ".venv"
+
+    check = check_environment_health(_env(env_path))
+
+    assert check.status == "BROKEN"
+    assert check.issues == ["environment directory missing or not a directory"]
+
+
 def test_check_environment_health_does_not_require_pyvenv_cfg_for_conda(
     tmp_path: Path,
 ) -> None:
@@ -109,7 +137,7 @@ def test_check_environment_health_detects_dangling_python_symlink(
     check = check_environment_health(_env(env_path))
 
     assert check.status == "BROKEN"
-    assert "dangling symlink: bin" in check.issues[0]
+    assert check.issues == ["dangling symlink: bin/python"]
 
 
 def test_format_health_report_counts_statuses(tmp_path: Path) -> None:

--- a/packages/python/tests/test_health.py
+++ b/packages/python/tests/test_health.py
@@ -69,23 +69,24 @@ def test_check_environment_health_warns_when_activate_script_is_missing(
     assert check.issues == ["missing activate script"]
 
 
-def test_check_environment_health_marks_missing_pyvenv_home_broken(
+def test_check_environment_health_warns_when_pyvenv_home_missing(
     tmp_path: Path,
 ) -> None:
+    # A relocated or --copies venv keeps a working interpreter even when the
+    # recorded base interpreter directory is gone, so this is a WARN, not BROKEN.
     env_path = _make_venv(tmp_path, "old", home=tmp_path / "missing-python")
 
     check = check_environment_health(_env(env_path))
 
-    assert check.status == "BROKEN"
-    assert check.issues == [
-        f"pyvenv.cfg home not found: {tmp_path / 'missing-python'}"
-    ]
+    assert check.status == "WARN"
+    assert check.issues == [f"pyvenv.cfg home not found: {tmp_path / 'missing-python'}"]
 
 
-def test_check_environment_health_marks_unreadable_pyvenv_cfg_broken(
+def test_check_environment_health_warns_when_pyvenv_cfg_unreadable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # An unreadable pyvenv.cfg does not stop the interpreter from running.
     env_path = _make_venv(tmp_path, "unreadable")
 
     def fail_parse(_: Path) -> dict[str, str]:
@@ -95,8 +96,24 @@ def test_check_environment_health_marks_unreadable_pyvenv_cfg_broken(
 
     check = check_environment_health(_env(env_path))
 
-    assert check.status == "BROKEN"
+    assert check.status == "WARN"
     assert check.issues == ["pyvenv.cfg unreadable: permission denied"]
+
+
+def test_check_environment_health_marks_missing_python_executable_broken(
+    tmp_path: Path,
+) -> None:
+    env_path = tmp_path / "noexe" / ".venv"
+    env_path.mkdir(parents=True)
+    (env_path / "pyvenv.cfg").write_text(
+        f"home = {tmp_path}\nversion = 3.12.1\n", encoding="utf-8"
+    )
+    _touch_executable(env_path / "bin" / "activate")
+
+    check = check_environment_health(_env(env_path))
+
+    assert check.status == "BROKEN"
+    assert check.issues == ["missing python executable"]
 
 
 def test_check_environment_health_marks_missing_env_directory_broken(
@@ -123,12 +140,67 @@ def test_check_environment_health_does_not_require_pyvenv_cfg_for_conda(
     assert check.issues == []
 
 
+def test_check_environment_health_finds_conda_interpreter_at_env_root(
+    tmp_path: Path,
+) -> None:
+    # Conda keeps the interpreter at the environment root on Windows
+    # (<env>/python.exe), not under bin/ or Scripts/.
+    env_path = tmp_path / "conda-win"
+    (env_path / "conda-meta").mkdir(parents=True)
+    _touch_executable(env_path / "python.exe")
+
+    check = check_environment_health(EnvInfo(path=env_path, env_type=EnvType.CONDA))
+
+    assert check.status == "OK"
+    assert check.issues == []
+
+
+def test_check_environment_health_ok_for_venv_without_pyvenv_cfg(
+    tmp_path: Path,
+) -> None:
+    # Legacy virtualenv-created envs have no pyvenv.cfg yet run fine; the
+    # detector still classifies them as VENV, so health must not call them BROKEN.
+    env_path = tmp_path / "legacy" / ".venv"
+    env_path.mkdir(parents=True)
+    _touch_executable(env_path / "bin" / "python")
+    _touch_executable(env_path / "bin" / "activate")
+    (env_path / "lib" / "python3.8" / "site-packages").mkdir(parents=True)
+
+    check = check_environment_health(_env(env_path))
+
+    assert check.status == "OK"
+    assert check.issues == []
+
+
+def test_check_environment_health_skips_checks_for_dotenv_dir(
+    tmp_path: Path,
+) -> None:
+    # A plain `.env` config directory is not an interpreter environment.
+    env_path = tmp_path / "project" / ".env"
+    env_path.mkdir(parents=True)
+    (env_path / "settings").write_text("KEY=value\n", encoding="utf-8")
+
+    check = check_environment_health(
+        EnvInfo(path=env_path, env_type=EnvType.DOTENV_DIR)
+    )
+
+    assert check.status == "OK"
+    assert check.issues == []
+
+
 def test_check_environment_health_detects_dangling_python_symlink(
     tmp_path: Path,
 ) -> None:
-    env_path = _make_venv(tmp_path, "dangling")
+    # A POSIX venv exposes the interpreter only at bin/python; if that is a
+    # dangling symlink the environment is broken.
+    env_path = tmp_path / "dangling" / ".venv"
+    env_path.mkdir(parents=True)
+    (env_path / "pyvenv.cfg").write_text(
+        f"home = {tmp_path}\nversion = 3.12.1\n", encoding="utf-8"
+    )
+    _touch_executable(env_path / "bin" / "activate")
     python_bin = env_path / "bin" / "python"
-    python_bin.unlink()
+    python_bin.parent.mkdir(parents=True, exist_ok=True)
     try:
         python_bin.symlink_to(env_path / "bin" / "missing-python")
     except OSError:
@@ -137,7 +209,7 @@ def test_check_environment_health_detects_dangling_python_symlink(
     check = check_environment_health(_env(env_path))
 
     assert check.status == "BROKEN"
-    assert check.issues == ["dangling symlink: bin/python"]
+    assert check.issues == [f"dangling symlink: {Path('bin') / 'python'}"]
 
 
 def test_format_health_report_counts_statuses(tmp_path: Path) -> None:
@@ -156,11 +228,18 @@ def test_format_health_report_counts_statuses(tmp_path: Path) -> None:
     ]
 
     report = format_health_report(checks, base_path=tmp_path)
+    rows = {
+        line.split()[0]: line
+        for line in report.splitlines()
+        if line.startswith(("ok", "warn", "broken"))
+    }
 
     assert "ENVIRONMENT HEALTH CHECK" in report
-    assert "ok" in report
-    assert "WARN" in report
-    assert "BROKEN" in report
+    assert "OK" in rows["ok"]
+    assert "WARN" in rows["warn"]
+    assert "missing activate script" in rows["warn"]
+    assert "BROKEN" in rows["broken"]
+    assert "missing python executable" in rows["broken"]
     assert "Healthy: 1 | Warnings: 1 | Broken: 1" in report
 
 
@@ -176,3 +255,38 @@ def test_health_to_dict_serializes_path(tmp_path: Path) -> None:
         "status": "WARN",
         "issues": ["missing activate script"],
     }
+
+
+def test_health_command_exits_nonzero_when_environment_broken(
+    tmp_path: Path,
+) -> None:
+    from typer.testing import CliRunner
+
+    from envoic.cli import app
+
+    env_path = tmp_path / "proj" / ".venv"
+    env_path.mkdir(parents=True)
+    # Discoverable as a venv (pyvenv.cfg present) but the interpreter is gone.
+    (env_path / "pyvenv.cfg").write_text(
+        f"home = {tmp_path}\nversion = 3.12.1\n", encoding="utf-8"
+    )
+
+    result = CliRunner().invoke(app, ["health", str(tmp_path), "--json"])
+
+    assert result.exit_code == 1
+    assert '"status": "BROKEN"' in result.stdout
+
+
+def test_health_command_exits_zero_for_healthy_environment(
+    tmp_path: Path,
+) -> None:
+    from typer.testing import CliRunner
+
+    from envoic.cli import app
+
+    _make_venv(tmp_path, "healthy")
+
+    result = CliRunner().invoke(app, ["health", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    assert '"status": "BROKEN"' not in result.stdout

--- a/packages/python/tests/test_health.py
+++ b/packages/python/tests/test_health.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from envoic.health import (
+    HealthCheck,
+    check_environment_health,
+    format_health_report,
+    health_to_dict,
+)
+from envoic.models import EnvInfo, EnvType
+
+
+def _touch_executable(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _make_venv(
+    tmp_path: Path,
+    name: str,
+    *,
+    home: Path | None = None,
+    with_activate: bool = True,
+) -> Path:
+    env_path = tmp_path / name / ".venv"
+    env_path.mkdir(parents=True)
+    (env_path / "pyvenv.cfg").write_text(
+        f"home = {home or tmp_path}\nversion = 3.12.1\n",
+        encoding="utf-8",
+    )
+
+    _touch_executable(env_path / "bin" / "python")
+    _touch_executable(env_path / "Scripts" / "python.exe")
+    (env_path / "lib" / "python3.12" / "site-packages").mkdir(parents=True)
+    (env_path / "Lib" / "site-packages").mkdir(parents=True)
+
+    if with_activate:
+        _touch_executable(env_path / "bin" / "activate")
+        _touch_executable(env_path / "Scripts" / "activate")
+
+    return env_path
+
+
+def _env(path: Path) -> EnvInfo:
+    return EnvInfo(path=path, env_type=EnvType.VENV)
+
+
+def test_check_environment_health_ok(tmp_path: Path) -> None:
+    env_path = _make_venv(tmp_path, "api")
+
+    check = check_environment_health(_env(env_path))
+
+    assert check.status == "OK"
+    assert check.issues == []
+
+
+def test_check_environment_health_warns_when_activate_script_is_missing(
+    tmp_path: Path,
+) -> None:
+    env_path = _make_venv(tmp_path, "worker", with_activate=False)
+
+    check = check_environment_health(_env(env_path))
+
+    assert check.status == "WARN"
+    assert check.issues == ["missing activate script"]
+
+
+def test_check_environment_health_marks_missing_pyvenv_home_broken(
+    tmp_path: Path,
+) -> None:
+    env_path = _make_venv(tmp_path, "old", home=tmp_path / "missing-python")
+
+    check = check_environment_health(_env(env_path))
+
+    assert check.status == "BROKEN"
+    assert check.issues == [
+        f"pyvenv.cfg home not found: {tmp_path / 'missing-python'}"
+    ]
+
+
+def test_check_environment_health_does_not_require_pyvenv_cfg_for_conda(
+    tmp_path: Path,
+) -> None:
+    env_path = tmp_path / "conda-env"
+    (env_path / "conda-meta").mkdir(parents=True)
+    _touch_executable(env_path / "bin" / "python")
+
+    check = check_environment_health(EnvInfo(path=env_path, env_type=EnvType.CONDA))
+
+    assert check.status == "OK"
+    assert check.issues == []
+
+
+def test_check_environment_health_detects_dangling_python_symlink(
+    tmp_path: Path,
+) -> None:
+    env_path = _make_venv(tmp_path, "dangling")
+    python_bin = env_path / "bin" / "python"
+    python_bin.unlink()
+    try:
+        python_bin.symlink_to(env_path / "bin" / "missing-python")
+    except OSError:
+        pytest.skip("symlinks are not available on this platform")
+
+    check = check_environment_health(_env(env_path))
+
+    assert check.status == "BROKEN"
+    assert "dangling symlink: bin" in check.issues[0]
+
+
+def test_format_health_report_counts_statuses(tmp_path: Path) -> None:
+    checks = [
+        HealthCheck(path=tmp_path / "ok" / ".venv", status="OK", issues=[]),
+        HealthCheck(
+            path=tmp_path / "warn" / ".venv",
+            status="WARN",
+            issues=["missing activate script"],
+        ),
+        HealthCheck(
+            path=tmp_path / "broken" / ".venv",
+            status="BROKEN",
+            issues=["missing python executable"],
+        ),
+    ]
+
+    report = format_health_report(checks, base_path=tmp_path)
+
+    assert "ENVIRONMENT HEALTH CHECK" in report
+    assert "ok" in report
+    assert "WARN" in report
+    assert "BROKEN" in report
+    assert "Healthy: 1 | Warnings: 1 | Broken: 1" in report
+
+
+def test_health_to_dict_serializes_path(tmp_path: Path) -> None:
+    check = HealthCheck(
+        path=tmp_path / "api" / ".venv",
+        status="WARN",
+        issues=["missing activate script"],
+    )
+
+    assert health_to_dict(check) == {
+        "path": str(tmp_path / "api" / ".venv"),
+        "status": "WARN",
+        "issues": ["missing activate script"],
+    }


### PR DESCRIPTION
Closes #23.

Adds a Python `health` command that scans discovered environments and reports common breakage:
- missing or non-executable Python binary
- dangling `bin/python` symlink
- missing or invalid `pyvenv.cfg` home
- missing activation script as a warning

It supports plain text output and `--json` for scripts.

Tests:
- `packages\\python\\.venv\\Scripts\\python.exe -m pytest packages\\python\\tests\\test_health.py -q`
- `packages\\python\\.venv\\Scripts\\python.exe -m pytest packages\\python\\tests -q -k `"not path_modes and not format_env_display_path_relative_and_strip`"`
- `packages\\python\\.venv\\Scripts\\python.exe -m py_compile packages\\python\\src\\envoic\\cli.py packages\\python\\src\\envoic\\health.py packages\\python\\tests\\test_health.py`
- CLI smoke for `health` text and `health --json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new health check command to inspect Python environments and report their status.
  * Health results can now be shown as JSON or as a formatted console report, with rich text support.

* **Bug Fixes**
  * Improved detection of broken environments, missing interpreters, unreadable configuration files, and dangling symlinks.
  * Added clearer warnings for incomplete environment setup and better handling of supported environment types.

* **Tests**
  * Expanded coverage for healthy, warning, and broken environment cases, plus CLI output and exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->