### PR TITLE
fix(cli): error on conflicting --show-artifacts and --no-artifacts

### DIFF
--- a/packages/python/src/envoic/cli.py
+++ b/packages/python/src/envoic/cli.py
@@ -168,6 +168,13 @@ def scan(
     ),
 ) -> None:
     """Scan a filesystem path for Python environments."""
+    if show_artifacts and not include_artifacts:
+        typer.echo(
+            "Error: --show-artifacts cannot be used together with --no-artifacts.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
     result = _build_scan_result(
         path,
         depth,

--- a/packages/python/tests/test_cli.py
+++ b/packages/python/tests/test_cli.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from envoic.cli import app
+
+runner = CliRunner()
+
+
+def test_scan_rejects_conflicting_artifact_flags(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["scan", str(tmp_path), "--show-artifacts", "--no-artifacts"],
+    )
+
+    assert result.exit_code == 1
+    assert "cannot be used together" in result.output.lower()
+
+
+def test_scan_allows_show_artifacts_with_default_artifacts(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["scan", str(tmp_path), "--show-artifacts"])
+
+    assert result.exit_code == 0


### PR DESCRIPTION
Reimplements #21 by @Riyaa-Bajpai on top of the current `main` layout.

## Problem
Passing `--show-artifacts` together with `--no-artifacts` to `envoic scan`
asked the report to render artifact-detail sections while artifact detection
was disabled, producing empty artifact output instead of a clear error.

## Fix
`scan` now validates the combination up front and exits with code 1 and a
clear message:

    Error: --show-artifacts cannot be used together with --no-artifacts.

## Why a new PR instead of updating #21
#21 was opened against the pre-monorepo layout (it edits `src/envoic/cli.py`,
which is now `packages/python/src/envoic/cli.py`) and was 33 commits behind
`main`, so it could not be rebased cleanly. Its code also had an
IndentationError and a misplaced test. This PR keeps the original intent and
credits Riya as co-author.

## Tests
- New `packages/python/tests/test_cli.py` covering the rejected combination and
  the still-valid `--show-artifacts` (default artifacts) case.
- Full suite: 49 passed. ruff lint + format + pre-commit hooks pass.