### PR TITLE
fix(ci): allow same-version npm publish in JS release workflow

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -63,7 +63,10 @@ jobs:
             exit 1
           fi
 
-          npm version "$VERSION" --no-git-tag-version
+          # --allow-same-version: package.json may already be at the release
+          # version (it is committed in-repo), and `npm version` otherwise
+          # errors with "Version not changed" and aborts the publish.
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Show publish metadata
         run: |


### PR DESCRIPTION
## Problem
The `v0.1.0` release failed in **Publish JS Package** (run [28446104137](https://github.com/mahimailabs/envoic/actions/runs/28446104137)) at the *Set version from release tag* step:

```
npm error Version not changed
```

`packages/js/package.json` is committed at the release version (`0.1.0`, since `60f58a2`), so `npm version 0.1.0` is a no-op and `npm version` aborts with a non-zero exit before the build/publish steps. Result: PyPI got `0.1.0` but npm is still on `0.0.10`.

## Fix
Pass `--allow-same-version` to `npm version` so a pre-set package.json version is not fatal and the publish proceeds. Idempotent whether or not package.json was pre-bumped.

## Follow-up
After merge, publish `0.1.0` to npm via the workflow's `workflow_dispatch` (version `0.1.0`).