### PR TITLE
chore(js): bump package to 0.1.1 for npm release

### DIFF
--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envoic",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envoic",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envoic",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Discover and manage node modules and JS artifacts on your system",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps the JS package (`packages/js`) from `0.1.0` to `0.1.1`.

## Why
`envoic@0.1.0` was published then unpublished on npm back in February, and npm permanently reserves unpublished version numbers. The `v0.1.0` release therefore failed with:

```
Cannot publish over previously published version "0.1.0".
```

`0.1.0` can never go to npm, so the JS package needs a fresh version to ship. PyPI already has `0.1.0`; moving both to `0.1.1` realigns them.

## Scope
- Only `packages/js/package.json` + `package-lock.json` (root `envoic` version). The `yocto-queue` dependency entry is untouched.
- **Python needs no change**: its version is VCS/tag-driven (`[tool.hatch.version] source = "vcs"`), so tagging `v0.1.1` yields `0.1.1` automatically.

## ⚠️ Merge order
This must merge **together with #43** (`--allow-same-version`) before cutting the release. Otherwise the `v0.1.1` release re-hits *"Version not changed"*, since `package.json` will already be at `0.1.1`.

## Release steps (after both merge)
1. Create release/tag `v0.1.1` → Python publishes to PyPI, JS publishes to npm.
2. Verify `npm view envoic version` shows `0.1.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the JavaScript package version from `0.1.0` to `0.1.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->